### PR TITLE
Make `quarkus.http.port` parameterized and allow clients to set it.

### DIFF
--- a/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/ProcessState.java
+++ b/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/ProcessState.java
@@ -124,7 +124,15 @@ public class ProcessState {
         .getSystemProperties()
         .get()
         .forEach((k, v) -> command.add(String.format("-D%s=%s", k, v)));
-    command.add("-Dquarkus.http.port=0");
+
+    // if the quarkus.http.port was passed by the caller via jvmArguments,
+    // it will use it as is and do not add the `quarkus.http.port` to command line again.
+    // If it is not defined, set to 0 to start on the random port
+    if (!containsQuarkusPortSetting(command)) {
+      // use random port
+      command.add("-Dquarkus.http.port=0");
+    }
+
     command.add("-jar");
     command.add(execJar.getAbsolutePath());
     command.addAll(extension.getArguments().get());
@@ -206,5 +214,9 @@ public class ProcessState {
             + "Set the Java-Home for a compatible JVM using the environment variable JDK%d_HOME or "
             + "JAVA%d_HOME.",
         version, version, version);
+  }
+
+  private boolean containsQuarkusPortSetting(List<String> command) {
+    return command.stream().anyMatch(p -> p.contains("quarkus.http.port"));
   }
 }

--- a/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/QuarkusAppExtension.java
+++ b/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/QuarkusAppExtension.java
@@ -42,7 +42,9 @@ public class QuarkusAppExtension {
         project
             .getObjects()
             .mapProperty(String.class, String.class)
-            .convention(Collections.singletonMap("quarkus.http.port", "0"));
+            .convention(
+                Collections.singletonMap(
+                    "quarkus.http.port", System.getProperty("quarkus.http.port", "0")));
     arguments = project.getObjects().listProperty(String.class);
     jvmArguments = project.getObjects().listProperty(String.class);
     javaVersion = project.getObjects().property(Integer.class).convention(11);

--- a/apprunner-maven-plugin/src/main/java/org/projectnessie/quarkus/maven/QuarkusAppStartMojo.java
+++ b/apprunner-maven-plugin/src/main/java/org/projectnessie/quarkus/maven/QuarkusAppStartMojo.java
@@ -255,7 +255,14 @@ public class QuarkusAppStartMojo extends AbstractQuarkusAppMojo {
       systemProperties.forEach(
           (k, v) -> command.add(String.format("-D%s=%s", k.toString(), v.toString())));
     }
-    command.add("-Dquarkus.http.port=0");
+
+    // if the quarkus.http.port was passed by the caller via jvmArguments,
+    // it will use it as is and do not add the `quarkus.http.port` to command line again.
+    // If it is not defined, set to 0 to start on the random port
+    if (!containsQuarkusPortSetting(command)) {
+      // use random port
+      command.add("-Dquarkus.http.port=0");
+    }
     command.add("-jar");
     command.add(execJar);
     if (arguments != null) {
@@ -304,5 +311,9 @@ public class QuarkusAppStartMojo extends AbstractQuarkusAppMojo {
     } catch (Exception e) {
       throw new MojoExecutionException(String.format("Failed to start the process %s", command), e);
     }
+  }
+
+  private boolean containsQuarkusPortSetting(List<String> command) {
+    return command.stream().anyMatch(p -> p.contains("quarkus.http.port"));
   }
 }

--- a/apprunner-maven-plugin/src/test/java/org/projectnessie/quarkus/maven/ITNessieMavenPlugin.java
+++ b/apprunner-maven-plugin/src/test/java/org/projectnessie/quarkus/maven/ITNessieMavenPlugin.java
@@ -75,6 +75,24 @@ class ITNessieMavenPlugin {
   @MavenTest
   @MavenGoal("verify")
   @MavenOption(MavenCLIOptions.ERRORS)
+  void quarkusPortParameterized(MavenExecutionResult result) {
+    assertThat(result)
+        .isSuccessful()
+        .out()
+        .info()
+        .anyMatch(
+            s ->
+                s.matches(
+                    "Starting process: .*-jar .*/nessie-quarkus-.*-runner.jar, additional env: .*HELLO=world.*"))
+        .anyMatch(s -> s.matches("Starting process: .*java.* -Dfoo=bar .*"))
+        // the expected 1111 port is provided in the pom.xml jvmArgs section.
+        .anyMatch(s -> s.matches("Starting process: .*java.* -Dquarkus.http.port=1111 .*"))
+        .anyMatch(s -> s.matches("Quarkus application stopped."));
+  }
+
+  @MavenTest
+  @MavenGoal("verify")
+  @MavenOption(MavenCLIOptions.ERRORS)
   void unknownJdk(MavenExecutionResult result) {
     assertThat(result)
         .isFailure()

--- a/apprunner-maven-plugin/src/test/resources-its/org/projectnessie/quarkus/maven/ITNessieMavenPlugin/quarkusPortParameterized/pom.xml
+++ b/apprunner-maven-plugin/src/test/resources-its/org/projectnessie/quarkus/maven/ITNessieMavenPlugin/quarkusPortParameterized/pom.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2020 Dremio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.projectnessie.it-test</groupId>
+  <artifactId>nessie-apprunner-maven-it</artifactId>
+  <version>0.42-SNAPSHOT</version>
+
+  <properties>
+    <maven.compiler.release>8</maven.compiler.release>
+    <nessie.version-for-test>0.21.2</nessie.version-for-test>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>@junit.version@</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>@junit.version@</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>@project.groupId@</groupId>
+      <artifactId>nessie-client</artifactId>
+      <version>${nessie.version-for-test}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <!-- without this, you get NPE rather than useful messages with Maven + JDK11 -->
+          <forceJavacCompilerUse>true</forceJavacCompilerUse>
+          <target>8</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <appArtifactId>org.projectnessie:nessie-quarkus:jar:runner:${nessie.version-for-test}</appArtifactId>
+          <systemProperties>
+            <foo>bar</foo>
+          </systemProperties>
+          <environment>
+            <HELLO>world</HELLO>
+          </environment>
+          <jvmArguments>
+            <jvmArgument>-Dquarkus.http.port=1111</jvmArgument>
+          </jvmArguments>
+        </configuration>
+        <executions>
+          <execution>
+            <id>start</id>
+            <phase>pre-integration-test</phase>
+            <goals><goal>start</goal></goals>
+          </execution>
+          <execution>
+            <id>stop</id>
+            <phase>post-integration-test</phase>
+            <goals><goal>stop</goal></goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/apprunner-maven-plugin/src/test/resources-its/org/projectnessie/quarkus/maven/ITNessieMavenPlugin/quarkusPortParameterized/src/test/java/org/projectnessie/quarkus/mavenit/TestSimulatingTestUsingThePlugin.java
+++ b/apprunner-maven-plugin/src/test/resources-its/org/projectnessie/quarkus/maven/ITNessieMavenPlugin/quarkusPortParameterized/src/test/java/org/projectnessie/quarkus/mavenit/TestSimulatingTestUsingThePlugin.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.quarkus.mavenit;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.projectnessie.client.api.NessieApiV1;
+import org.projectnessie.client.http.HttpClientBuilder;
+import org.projectnessie.model.Branch;
+
+/**
+ * This is not a test for the plugin itself, this is a test that is run BY the test for the plugin.
+ */
+class TestSimulatingTestUsingThePlugin {
+  @Test
+  void pingNessie() throws Exception {
+    String port = System.getProperty("quarkus.http.test-port");
+    assertNotNull(port);
+    String url = System.getProperty("quarkus.http.test-url");
+    assertNotNull(url);
+
+    String uri = String.format("http://127.0.0.1:%s/api/v1", port);
+
+    NessieApiV1 client = HttpClientBuilder.builder().withUri(uri).build(NessieApiV1.class);
+    // Just some simple REST request to verify that Nessie is started - no fancy interactions w/ Nessie
+    client.getConfig();
+
+    // We have seen that HTTP/POST requests can fail with conflicting dependencies
+    client.createReference().sourceRefName("main").reference(Branch.of("foo-" + System.nanoTime(), null)).create();
+  }
+}


### PR DESCRIPTION
It allows clients of the runner to specify the `quarkus.http.port` instead of using a random port.
For example, usage, see the test:
https://github.com/projectnessie/nessie-apprunner/compare/main...tomekl007:make_quarkus_port_parameterized?expand=1#diff-ef37744e885c16a48a3eafa104be331829193c4728e6c52447614e1517a236e2R75-R91
And the `pom.xml` `<jvmArgs>` section:
https://github.com/projectnessie/nessie-apprunner/compare/main...tomekl007:make_quarkus_port_parameterized?expand=1#diff-908925841d2aa68d7aa735257381705c581ebb91fa45d6440b842e0af3b12262R77

The change is backward compatible, so when `quarkus.http.port` is not set, it will use the random port as before