### PR TITLE
Propagate the random quarkus port via a `System.property`

### DIFF
--- a/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/QuarkusAppExtension.java
+++ b/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/QuarkusAppExtension.java
@@ -51,7 +51,7 @@ public class QuarkusAppExtension {
     httpListenPortProperty =
         project.getObjects().property(String.class).convention("quarkus.http.test-port");
     // set the port as the property, to allow clients of the extension to get the port.
-    System.setProperty("quarkus.http.test-port", httpListenPortProperty);
+    System.setProperty("quarkus.http.test-port", httpListenPortProperty.get());
     workingDirectory =
         project
             .getObjects()

--- a/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/QuarkusAppExtension.java
+++ b/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/QuarkusAppExtension.java
@@ -50,6 +50,8 @@ public class QuarkusAppExtension {
         project.getObjects().property(String.class).convention("quarkus.http.test-url");
     httpListenPortProperty =
         project.getObjects().property(String.class).convention("quarkus.http.test-port");
+    // set the port as the property, to allow clients of the extension to get the port.
+    System.setProperty("quarkus.http.test-port", httpListenPortProperty);
     workingDirectory =
         project
             .getObjects()

--- a/apprunner-maven-plugin/src/main/java/org/projectnessie/quarkus/maven/QuarkusAppStartMojo.java
+++ b/apprunner-maven-plugin/src/main/java/org/projectnessie/quarkus/maven/QuarkusAppStartMojo.java
@@ -295,9 +295,10 @@ public class QuarkusAppStartMojo extends AbstractQuarkusAppMojo {
 
       Properties projectProperties = getProject().getProperties();
       projectProperties.setProperty(httpListenUrlProperty, listenUrl);
-      projectProperties.setProperty(
-          httpListenPortProperty, Integer.toString(URI.create(listenUrl).getPort()));
-
+      String quarkusPort = Integer.toString(URI.create(listenUrl).getPort());
+      projectProperties.setProperty(httpListenPortProperty, quarkusPort);
+      // set the port as the property, to allow clients of the extension to get the port.
+      System.setProperty("quarkus.http.test-port", quarkusPort);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new MojoExecutionException(String.format("Process-start interrupted: %s", command), e);


### PR DESCRIPTION
To allow clients to extract the value of the randomly assigned quarkus port, we need to propagate it via `System.property`