### PR TITLE
Adopt release-workflow to new dependabot-automerge commit status

### DIFF
--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Check commit status
       run: |
         echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
-        gh api repos/projectnessie/nessie-apprunner/commits/${GITHUB_SHA}/check-runs --jq 'if ([.check_runs[] | select(.name | endswith(" release") or startswith("codecov/") or startswith("Report ") | not ) | select(.conclusion != "skipped") | .conclusion // "pending" ] | unique == ["success"]) then "OK" else error("Commit checks are not OK") end'
+        gh api repos/projectnessie/nessie-apprunner/commits/${GITHUB_SHA}/check-runs --jq 'if ([.check_runs[] | select(.name | endswith(" release") or startswith("Dependabot ") or startswith("codecov/") or startswith("Report ") | not ) | select(.conclusion != "skipped") | .conclusion // "pending" ] | unique == ["success"]) then "OK" else error("Commit checks are not OK") end'
 
     ### BEGIN runner setup
     - name: Checkout


### PR DESCRIPTION
The commit status of the new Dependabot Automerge WF needs to be ignored
during the commit status check.