### PR TITLE
Gradle-Plugin: ability to filter tasks

### DIFF
--- a/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/QuarkusAppExtension.java
+++ b/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/QuarkusAppExtension.java
@@ -16,12 +16,16 @@
 package org.projectnessie.quarkus.gradle;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import org.gradle.api.Project;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.TaskProvider;
+import org.gradle.api.tasks.testing.Test;
 
 public class QuarkusAppExtension {
   private final MapProperty<String, String> environment;
@@ -35,6 +39,7 @@ public class QuarkusAppExtension {
   private final RegularFileProperty workingDirectory;
   private final Property<Long> timeToListenUrlMillis;
   private final Property<Long> timeToStopMillis;
+  private final List<TaskProvider<Test>> includedTasks = new ArrayList<>();
 
   public QuarkusAppExtension(Project project) {
     environment = project.getObjects().mapProperty(String.class, String.class);
@@ -102,5 +107,18 @@ public class QuarkusAppExtension {
 
   public Property<Long> getTimeToStopMillis() {
     return timeToStopMillis;
+  }
+
+  public QuarkusAppExtension includeTask(TaskProvider<Test> task) {
+    includedTasks.add(task);
+    return this;
+  }
+
+  boolean taskIsApplicable(Test test) {
+    if (includedTasks.isEmpty()) {
+      return true;
+    }
+    return includedTasks.stream()
+        .anyMatch(taskProvider -> taskProvider.getName().equals(test.getName()));
   }
 }

--- a/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/QuarkusAppPlugin.java
+++ b/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/QuarkusAppPlugin.java
@@ -45,17 +45,19 @@ public class QuarkusAppPlugin implements Plugin<Project> {
                 "References the Nessie-Quarkus server dependency, only a single dependency allowed.");
 
     // Cannot use the task name "test" here, because the "test" task might not have been registered
-    // yet.
-    // This `withType(Test.class...)` construct will configure any current and future task of type
-    // `Test`.
+    // yet. This `withType(Test.class...)` construct will configure any current and future task of
+    // type `Test`.
     target
         .getTasks()
         .withType(
             Test.class,
             new Action<Test>() {
-              @SuppressWarnings("UnstableApiUsage") // omit warning about `Property`+`MapProperty`
               @Override
               public void execute(Test test) {
+                if (!extension.taskIsApplicable(test)) {
+                  return;
+                }
+
                 // Add the StartTask's properties as "inputs" to the Test task, so the Test task is
                 // executed, when those properties change.
                 test.getInputs().properties(extension.getEnvironment().get());


### PR DESCRIPTION
Allows Gradle build scripts to specify only certain Gradle `Test` tasks that require a running Nessie server.