### PR TITLE
Add non-input variants for environment, system-properties, arguments and jvm-arguments

### DIFF
--- a/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/ProcessState.java
+++ b/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/ProcessState.java
@@ -120,14 +120,20 @@ public class ProcessState {
     List<String> command = new ArrayList<>();
     command.add(javaVM.getJavaExecutable().toString());
     command.addAll(extension.getJvmArguments().get());
+    command.addAll(extension.getJvmArgumentsNonInput().get());
     extension
         .getSystemProperties()
+        .get()
+        .forEach((k, v) -> command.add(String.format("-D%s=%s", k, v)));
+    extension
+        .getSystemPropertiesNonInput()
         .get()
         .forEach((k, v) -> command.add(String.format("-D%s=%s", k, v)));
     command.add("-Dquarkus.http.port=0");
     command.add("-jar");
     command.add(execJar.getAbsolutePath());
     command.addAll(extension.getArguments().get());
+    command.addAll(extension.getArgumentsNonInput().get());
 
     if (testTask.getLogger().isDebugEnabled()) {
       testTask.getLogger().debug("Starting process: {}", command);
@@ -137,6 +143,10 @@ public class ProcessState {
 
     ProcessBuilder processBuilder = new ProcessBuilder().command(command);
     extension.getEnvironment().get().forEach((k, v) -> processBuilder.environment().put(k, v));
+    extension
+        .getEnvironmentNonInput()
+        .get()
+        .forEach((k, v) -> processBuilder.environment().put(k, v));
     processBuilder.directory(workDir.toFile());
 
     try {

--- a/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/QuarkusAppExtension.java
+++ b/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/QuarkusAppExtension.java
@@ -29,9 +29,13 @@ import org.gradle.api.tasks.testing.Test;
 
 public class QuarkusAppExtension {
   private final MapProperty<String, String> environment;
+  private final MapProperty<String, String> environmentNonInput;
   private final MapProperty<String, String> systemProperties;
+  private final MapProperty<String, String> systemPropertiesNonInput;
   private final ListProperty<String> arguments;
+  private final ListProperty<String> argumentsNonInput;
   private final ListProperty<String> jvmArguments;
+  private final ListProperty<String> jvmArgumentsNonInput;
   private final Property<Integer> javaVersion;
   private final Property<String> httpListenPortProperty;
   private final Property<String> httpListenUrlProperty;
@@ -43,13 +47,17 @@ public class QuarkusAppExtension {
 
   public QuarkusAppExtension(Project project) {
     environment = project.getObjects().mapProperty(String.class, String.class);
+    environmentNonInput = project.getObjects().mapProperty(String.class, String.class);
     systemProperties =
         project
             .getObjects()
             .mapProperty(String.class, String.class)
             .convention(Collections.singletonMap("quarkus.http.port", "0"));
+    systemPropertiesNonInput = project.getObjects().mapProperty(String.class, String.class);
     arguments = project.getObjects().listProperty(String.class);
+    argumentsNonInput = project.getObjects().listProperty(String.class);
     jvmArguments = project.getObjects().listProperty(String.class);
+    jvmArgumentsNonInput = project.getObjects().listProperty(String.class);
     javaVersion = project.getObjects().property(Integer.class).convention(11);
     httpListenUrlProperty =
         project.getObjects().property(String.class).convention("quarkus.http.test-url");
@@ -69,16 +77,32 @@ public class QuarkusAppExtension {
     return systemProperties;
   }
 
+  public MapProperty<String, String> getSystemPropertiesNonInput() {
+    return systemPropertiesNonInput;
+  }
+
   public MapProperty<String, String> getEnvironment() {
     return environment;
+  }
+
+  public MapProperty<String, String> getEnvironmentNonInput() {
+    return environmentNonInput;
   }
 
   public ListProperty<String> getArguments() {
     return arguments;
   }
 
+  public ListProperty<String> getArgumentsNonInput() {
+    return argumentsNonInput;
+  }
+
   public ListProperty<String> getJvmArguments() {
     return jvmArguments;
+  }
+
+  public ListProperty<String> getJvmArgumentsNonInput() {
+    return jvmArgumentsNonInput;
   }
 
   public Property<Integer> getJavaVersion() {


### PR DESCRIPTION
"Non-input" means that these values do not become part of the test task's input, which
determines the cache-key for the task.

"Non-input" values can be used for "random TCP ports", system dependent heap settings
and other system/runtime specific settings.