### PR TITLE
Gradle: Allow Nessie-Quarkus runner on any task type

### DIFF
--- a/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/NessieQuarkusTaskConfigurer.java
+++ b/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/NessieQuarkusTaskConfigurer.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.quarkus.gradle;
+
+import static org.projectnessie.quarkus.gradle.QuarkusAppPlugin.APP_CONFIG_NAME;
+
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.file.RegularFile;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.TaskInputs;
+
+/** Configures the task for which the Nessie-Quarkus process shall be started. */
+public class NessieQuarkusTaskConfigurer<T extends Task> implements Action<T> {
+
+  private final Action<T> postStartAction;
+
+  public NessieQuarkusTaskConfigurer(Action<T> postStartAction) {
+    this.postStartAction = postStartAction;
+  }
+
+  @SuppressWarnings(
+      "Convert2Lambda") // Gradle complains when using lambdas (build-cache won't wonk)
+  @Override
+  public void execute(T task) {
+    Project project = task.getProject();
+
+    Configuration appConfig = project.getConfigurations().getByName(APP_CONFIG_NAME);
+    QuarkusAppExtension extension = project.getExtensions().getByType(QuarkusAppExtension.class);
+
+    // Add the StartTask's properties as "inputs" to the Test task, so the Test task is
+    // executed, when those properties change.
+    TaskInputs inputs = task.getInputs();
+    inputs.properties(extension.getEnvironment().get());
+    inputs.properties(extension.getSystemProperties().get());
+    inputs.property("nessie.quarkus.arguments", extension.getArguments().get().toString());
+    inputs.property("nessie.quarkus.jvmArguments", extension.getJvmArguments().get().toString());
+    RegularFile execJar = extension.getExecutableJar().getOrNull();
+    if (execJar != null) {
+      inputs.file(execJar).withPathSensitivity(PathSensitivity.RELATIVE);
+    }
+    inputs.property("nessie.quarkus.javaVersion", extension.getJavaVersion().get());
+
+    inputs.files(appConfig);
+
+    ProcessState processState = new ProcessState();
+
+    // Start the Nessie-Quarkus-App only when the Test task actually runs
+
+    task.doFirst(
+        new Action<Task>() {
+          @Override
+          public void execute(Task ignore) {
+            processState.quarkusStart(task);
+            if (postStartAction != null) {
+              postStartAction.execute(task);
+            }
+          }
+        });
+    task.doLast(
+        new Action<Task>() {
+          @Override
+          public void execute(Task ignore) {
+            processState.quarkusStop(task);
+          }
+        });
+  }
+}


### PR DESCRIPTION
Before this change, the plugin could only be applied on tasks of
type `Test`.

This change allows using the plugin on any type of Gradle tasks.

Tasks of `Test`, actually all tasks that implement `JavaForkOptions`,
get automatically configured - i.e. the relevant
properties for URL + port injected as system properties.

Other types of tasks can get the two values via the `extra`
properties and use the `includeTask` and `includeTasks` methods
on this plugin's `QuarkusAppExtension` taking the `Action<Task>`,
which will be called after the Nessie-Quarkus process has been started.