### PR TITLE
Upgrade codecov-action to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,8 @@ jobs:
           **/target/failsafe-reports/*
           **/build/reports/*
           **/build/test-results/*
-    - uses: codecov/codecov-action@v1
+    - uses: codecov/codecov-action@v2
       with:
+        fail_ci_if_error: true
         flags: java
-        files: |
-          code-coverage/target/site/jacoco-aggregate-all/jacoco.xml
-          apprunner-gradle-plugin/build/reports/jacoco/codeCoverageReport/codeCoverageReport.xml
+        files: code-coverage/target/site/jacoco-aggregate-all/jacoco.xml,apprunner-gradle-plugin/build/reports/jacoco/codeCoverageReport/codeCoverageReport.xml


### PR DESCRIPTION
Since v1 is deprecated:
https://github.com/codecov/codecov-action#%EF%B8%8F--deprecration-of-v1