### PR TITLE
Automatically stop "left over" Nessie processes

### DIFF
--- a/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/NessieRunnerService.java
+++ b/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/NessieRunnerService.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2020 Dremio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.projectnessie.quarkus.gradle;
+
+import java.util.IdentityHashMap;
+import java.util.Map;
+import org.gradle.api.Task;
+import org.gradle.api.services.BuildService;
+import org.gradle.api.services.BuildServiceParameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class NessieRunnerService
+    implements BuildService<BuildServiceParameters.None>, AutoCloseable {
+  private static final Logger LOGGER = LoggerFactory.getLogger(NessieRunnerService.class);
+
+  private final Map<Task, ProcessState> processes = new IdentityHashMap<>();
+
+  @Override
+  public void close() {
+    synchronized (processes) {
+      if (!processes.isEmpty()) {
+        LOGGER.warn("Cleaning up {} Nessie Quarkus services", processes.size());
+      }
+      for (ProcessState state : processes.values()) {
+        state.quarkusStop(LOGGER);
+      }
+    }
+  }
+
+  public void register(ProcessState processState, Task task) {
+    synchronized (processes) {
+      processes.put(task, processState);
+    }
+  }
+
+  public void finished(Task task) {
+    ProcessState state;
+    synchronized (processes) {
+      state = processes.remove(task);
+    }
+    state.quarkusStop(task.getLogger());
+  }
+}

--- a/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/ProcessState.java
+++ b/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/ProcessState.java
@@ -39,6 +39,7 @@ import org.gradle.api.tasks.testing.Test;
 import org.gradle.process.JavaForkOptions;
 import org.projectnessie.quarkus.runner.JavaVM;
 import org.projectnessie.quarkus.runner.ProcessHandler;
+import org.slf4j.Logger;
 
 public class ProcessState {
 
@@ -202,15 +203,15 @@ public class ProcessState {
     }
   }
 
-  void quarkusStop(Task task) {
+  void quarkusStop(Logger logger) {
     if (processHandler == null) {
-      task.getLogger().debug("No application found.");
+      logger.debug("No application found.");
       return;
     }
 
     try {
       processHandler.stop();
-      task.getLogger().info("Quarkus application stopped.");
+      logger.info("Quarkus application stopped.");
     } catch (Exception e) {
       throw new RuntimeException(e);
     } finally {

--- a/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/QuarkusAppExtension.java
+++ b/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/QuarkusAppExtension.java
@@ -24,6 +24,7 @@ import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskCollection;
 import org.gradle.api.tasks.TaskProvider;
 
@@ -44,7 +45,12 @@ public class QuarkusAppExtension {
   private final Property<Long> timeToListenUrlMillis;
   private final Property<Long> timeToStopMillis;
 
-  public QuarkusAppExtension(Project project) {
+  private final Provider<NessieRunnerService> nessieRunnerServiceProvider;
+
+  public QuarkusAppExtension(
+      Project project, Provider<NessieRunnerService> nessieRunnerServiceProvider) {
+    this.nessieRunnerServiceProvider = nessieRunnerServiceProvider;
+
     environment = project.getObjects().mapProperty(String.class, String.class);
     environmentNonInput = project.getObjects().mapProperty(String.class, String.class);
     systemProperties =
@@ -138,7 +144,8 @@ public class QuarkusAppExtension {
 
   public <T extends Task> QuarkusAppExtension includeTasks(
       TaskCollection<T> taskCollection, Action<T> postStartAction) {
-    taskCollection.configureEach(new NessieQuarkusTaskConfigurer<>(postStartAction));
+    taskCollection.configureEach(
+        new NessieQuarkusTaskConfigurer<>(postStartAction, nessieRunnerServiceProvider));
     return this;
   }
 
@@ -148,7 +155,8 @@ public class QuarkusAppExtension {
 
   public <T extends Task> QuarkusAppExtension includeTask(
       TaskProvider<T> taskProvider, Action<T> postStartAction) {
-    taskProvider.configure(new NessieQuarkusTaskConfigurer<>(postStartAction));
+    taskProvider.configure(
+        new NessieQuarkusTaskConfigurer<>(postStartAction, nessieRunnerServiceProvider));
     return this;
   }
 }

--- a/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/QuarkusAppPlugin.java
+++ b/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/QuarkusAppPlugin.java
@@ -17,6 +17,7 @@ package org.projectnessie.quarkus.gradle;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.provider.Provider;
 
 public class QuarkusAppPlugin implements Plugin<Project> {
 
@@ -36,6 +37,14 @@ public class QuarkusAppPlugin implements Plugin<Project> {
                     .setDescription(
                         "References the Nessie-Quarkus server dependency, only a single dependency allowed."));
 
-    project.getExtensions().create(EXTENSION_NAME, QuarkusAppExtension.class, project);
+    Provider<NessieRunnerService> runnerService =
+        project
+            .getGradle()
+            .getSharedServices()
+            .registerIfAbsent("nessie-quarkus-runner", NessieRunnerService.class, spec -> {});
+
+    project
+        .getExtensions()
+        .create(EXTENSION_NAME, QuarkusAppExtension.class, project, runnerService);
   }
 }


### PR DESCRIPTION
Use Gradle build service mechanism to automatically stop all Nessie Quarkus processes at the end of each build.

Background is that if a Gradle task failed, the remaining task actions may not be executed, leading to a "lost" Nessie Quarkus process.

The fix here is to use a Gradle build-service, which is guaranteed to be "closed" once the build finishes.

Side note: there is already a Java shutdown hook to kill potentially left-over Nessie Quarkus processes, but since the Gradle daemon is kept alive, the Nessie Quarkus processes will not be cleaned up via that mechanism.