### PR TITLE
Fix class-cast exception in Gradle plugin

### DIFF
--- a/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/NessieQuarkusTaskConfigurer.java
+++ b/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/NessieQuarkusTaskConfigurer.java
@@ -62,27 +62,27 @@ public class NessieQuarkusTaskConfigurer<T extends Task> implements Action<T> {
 
     inputs.files(appConfig);
 
-    ProcessState processState = new ProcessState();
-
     // Start the Nessie-Quarkus-App only when the Test task actually runs
 
     task.usesService(nessieRunnerServiceProvider);
     task.doFirst(
         new Action<Task>() {
+          @SuppressWarnings("unchecked")
           @Override
-          public void execute(Task ignore) {
-            nessieRunnerServiceProvider.get().register(processState, task);
-            processState.quarkusStart(task);
+          public void execute(Task t) {
+            ProcessState processState = new ProcessState();
+            nessieRunnerServiceProvider.get().register(processState, t);
+            processState.quarkusStart(t);
             if (postStartAction != null) {
-              postStartAction.execute(task);
+              postStartAction.execute((T) t);
             }
           }
         });
     task.doLast(
         new Action<Task>() {
           @Override
-          public void execute(Task ignore) {
-            nessieRunnerServiceProvider.get().finished(task);
+          public void execute(Task t) {
+            nessieRunnerServiceProvider.get().finished(t);
           }
         });
   }

--- a/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/NessieRunnerService.java
+++ b/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/NessieRunnerService.java
@@ -52,6 +52,8 @@ public abstract class NessieRunnerService
     synchronized (processes) {
       state = processes.remove(task);
     }
-    state.quarkusStop(task.getLogger());
+    if (state != null) {
+      state.quarkusStop(task.getLogger());
+    }
   }
 }

--- a/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/QuarkusAppPlugin.java
+++ b/apprunner-gradle-plugin/src/main/java/org/projectnessie/quarkus/gradle/QuarkusAppPlugin.java
@@ -15,6 +15,7 @@
  */
 package org.projectnessie.quarkus.gradle;
 
+import java.util.concurrent.ThreadLocalRandom;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.provider.Provider;
@@ -41,7 +42,13 @@ public class QuarkusAppPlugin implements Plugin<Project> {
         project
             .getGradle()
             .getSharedServices()
-            .registerIfAbsent("nessie-quarkus-runner", NessieRunnerService.class, spec -> {});
+            .registerIfAbsent(
+                // Make the build-service unique per project to prevent Gradle class-cast
+                // exceptions when the plugin's reloaded within the same build using different
+                // class loaders.
+                "nessie-quarkus-runner-" + ThreadLocalRandom.current().nextLong(),
+                NessieRunnerService.class,
+                spec -> {});
 
     project
         .getExtensions()


### PR DESCRIPTION
It seems that, Gradle can load the same plugin multiple times using different class loaders, which causes class-cast-exceptions, although it is implemented as recommended in the documentation: https://docs.gradle.org/current/userguide/build_services.html#registering_a_build_service

The workaround implemented here is to give each plugin's build service a unique name.

Sample exception:
`Caused by: java.lang.ClassCastException: class org.projectnessie.quarkus.gradle.NessieRunnerService$Inject cannot be cast to class org.projectnessie.quarkus.gradle.NessieRunnerService (org.projectnessie.quarkus.gradle.NessieRunnerService$Inject is in unnamed module of loader org.gradle.internal.classloader.VisitableURLClassLoader @532fbc65; org.projectnessie.quarkus.gradle.NessieRunnerService is in unnamed module of loader org.gradle.internal.classloader.VisitableURLClassLoader @45fa94aa)` This exception happened frequently for https://github.com/projectnessie/nessie/pull/5586