### PR TITLE
Gradle: allow using the configuration cache

### DIFF
--- a/.github/actions/dev-tool-java/action.yml
+++ b/.github/actions/dev-tool-java/action.yml
@@ -29,14 +29,6 @@ runs:
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml', '**/maven-wrapper.properties') }}
         restore-keys: |
           ${{ runner.os }}-maven-
-    - name: Cache Gradle packages
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle', '**/gradle-wrapper.properties') }}
-        restore-keys: ${{ runner.os }}-gradle-
 
     - name: Set up Maven toolchains.xml
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,18 +24,24 @@ on:
     types: [opened, synchronize, reopened]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository != 'projectnessie/nessie-apprunner' }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.head_commit.id }}-${{ github.event.pull_request.head.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   java:
-    name: Java/Maven
+    name: CI Java/Maven
     runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 3
+      matrix:
+        java-version: ['11', '17', '19']
 
     steps:
     - uses: actions/checkout@v3
     - name: Setup Java, Maven, Gradle
       uses: ./.github/actions/dev-tool-java
+      with:
+        java-version: ${{ matrix.java-version }}
 
     - name: Build with Maven
       env:
@@ -44,11 +50,18 @@ jobs:
         ./mvnw --batch-mode --threads 1C install javadoc:javadoc-no-fork -Pcode-coverage -Dtest.log.level=WARN
 
     - name: Build with Gradle
-      run: ./gradlew --rerun-tasks --no-daemon --info build
-      working-directory: ./gradle-plugin
+      uses: gradle/gradle-build-action@v2
+      env:
+        GRADLE_BUILD_ACTION_CACHE_KEY_ENVIRONMENT: java-${{ matrix.java-version }}
+      with:
+        build-root-directory: ./gradle-plugin
+        # -Pcode-coverage would enable Jacoco, but Gradle's testkit doesn't like Java agents,
+        # see https://docs.gradle.org/8.0.2/userguide/configuration_cache.html#config_cache:not_yet_implemented:testkit_build_with_java_agent
+        arguments: build --scan
 
     - name: Capture test results
       uses: actions/upload-artifact@v3
+      if: failure()
       with:
         name: test-results
         path: |
@@ -56,8 +69,22 @@ jobs:
           **/target/failsafe-reports/*
           **/build/reports/*
           **/build/test-results/*
+
     - uses: codecov/codecov-action@v3
+      if: matrix.java-version == '11'
       with:
         fail_ci_if_error: false
         flags: java
         files: code-coverage/target/site/jacoco-aggregate-all/jacoco.xml,gradle-plugin/build/reports/jacoco/codeCoverageReport/codeCoverageReport.xml
+
+  finish:
+    # 'Ci Success' is the (only) required check for PRs, so we can change the jobs above without
+    # having to update the GH configuration every time.
+    name: CI Success
+    runs-on: ubuntu-22.04
+    needs:
+      - java
+    steps:
+      # Intentionally empty job (for all GH WF) events so that the "required checks" setting
+      # only needs to contain this job as the only required check for PRs.
+      - run: echo "Success"

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -16,10 +16,13 @@
 
 plugins {
   id 'java-gradle-plugin'
-  id 'jacoco'
   id 'maven-publish'
   id 'com.gradle.plugin-publish' version '1.1.0'
   id "com.diffplug.spotless" version "6.18.0"
+}
+
+if (project.hasProperty("code-coverage")) {
+  plugins.apply('jacoco')
 }
 
 def mavenPropertiesFile = file('../target/project.properties')
@@ -84,6 +87,18 @@ test {
           'junit-version': junitVersion,
           'jackson-version': jacksonVersion
   ])
+  jvmArgs("--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+          "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+          "--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+          "--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+          "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+          "--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+          "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+          "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+          "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+          "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+          "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED",
+          "--add-opens=java.base/java.util=ALL-UNNAMED")
   useJUnitPlatform()
 }
 
@@ -100,8 +115,10 @@ dependencies {
   testImplementation("org.assertj:assertj-core:${assertjVersion}")
 }
 
-jacoco {
-  toolVersion = jacocoVersion
+if (project.hasProperty("code-coverage")) {
+  jacoco {
+    toolVersion = jacocoVersion
+  }
 }
 
 task codeCoverageReport(type:JacocoReport) {

--- a/gradle-plugin/gradle.properties
+++ b/gradle-plugin/gradle.properties
@@ -1,0 +1,23 @@
+# enable the Gradle build cache
+org.gradle.caching=true
+# enable Gradle parallel builds
+org.gradle.parallel=true
+# configure only necessary Gradle tasks
+org.gradle.configureondemand=true
+# also enable the configuration cache
+org.gradle.unsafe.configuration-cache=true
+# bump the Gradle daemon heap size (you can set bigger heap sizes as well)
+org.gradle.jvmargs=\
+  -Xms2g -Xmx2g -XX:MaxMetaspaceSize=768m \
+  -Dfile.encoding=UTF-8 \
+  -Duser.language=en -Duser.country=US -Duser.variant= \
+  --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED

--- a/gradle-plugin/src/main/java/org/projectnessie/nessierunner/gradle/NessieRunnerExtension.java
+++ b/gradle-plugin/src/main/java/org/projectnessie/nessierunner/gradle/NessieRunnerExtension.java
@@ -16,7 +16,6 @@
 package org.projectnessie.nessierunner.gradle;
 
 import java.io.File;
-import java.util.Collections;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
@@ -53,11 +52,7 @@ public class NessieRunnerExtension {
 
     environment = project.getObjects().mapProperty(String.class, String.class);
     environmentNonInput = project.getObjects().mapProperty(String.class, String.class);
-    systemProperties =
-        project
-            .getObjects()
-            .mapProperty(String.class, String.class)
-            .convention(Collections.singletonMap("quarkus.http.port", "0"));
+    systemProperties = project.getObjects().mapProperty(String.class, String.class);
     systemPropertiesNonInput = project.getObjects().mapProperty(String.class, String.class);
     arguments = project.getObjects().listProperty(String.class);
     argumentsNonInput = project.getObjects().listProperty(String.class);

--- a/gradle-plugin/src/test/java/org/projectnessie/nessierunner/gradle/TestNessieRunnerPlugin.java
+++ b/gradle-plugin/src/test/java/org/projectnessie/nessierunner/gradle/TestNessieRunnerPlugin.java
@@ -128,7 +128,7 @@ class TestNessieRunnerPlugin {
         .isEqualTo(TaskOutcome.FAILED);
     assertThat(Arrays.asList(result.getOutput().split("\n")))
         .contains(
-            "> Dependency org.projectnessie:nessie-quarkus:runner missing in configuration nessieQuarkusServer");
+            "> Neither does the configuration nessieQuarkusServer contain exactly one dependency (preferably org.projectnessie:nessie-quarkus:runner), nor is the runner jar specified in the nessieQuarkusApp extension.");
   }
 
   /**
@@ -160,13 +160,12 @@ class TestNessieRunnerPlugin {
         .isEqualTo(TaskOutcome.FAILED);
     assertThat(Arrays.asList(result.getOutput().split("\n")))
         .contains(
-            "> Configuration nessieQuarkusServer must only contain the org.projectnessie:nessie-quarkus:runner dependency, "
-                + "but resolves to these artifacts: "
-                + "org.projectnessie:nessie-quarkus:"
+            "> Expected configuration nessieQuarkusServer to resolve to exactly one artifact, "
+                + "but resolves to org.projectnessie:nessie-quarkus:"
                 + nessieVersionForTest
-                + ", "
-                + "org.projectnessie:nessie-model:"
-                + nessieVersionForTest);
+                + ", org.projectnessie:nessie-model:"
+                + nessieVersionForTest
+                + " (hint: do not enable transitive on the dependency)");
   }
 
   /**
@@ -349,7 +348,7 @@ class TestNessieRunnerPlugin {
     return GradleRunner.create()
         .withPluginClasspath()
         .withProjectDir(testProjectDir.toFile())
-        .withArguments("--build-cache", "--info", "--stacktrace", task)
+        .withArguments("--configuration-cache", "--build-cache", "--info", "--stacktrace", task)
         .withDebug(true)
         .forwardOutput();
   }


### PR DESCRIPTION
Gradle's configuration cache aims to avoid costly operations that happen during Gradle's configuration phase, which can be comparabily expensive.

However, using the configuration cache adds some constraints on everything (plugins, custom tasks, build scripts) used in a Gradle build. For example, capturing some types (e.g. `Configuration`, `DependencySet`) is not possible, need to narrow to "more precise" types (like `FileCollection`).

Also add a Java matrix CI for 11, 17, 19