### PR TITLE
Gradle plugin: Fix after Gradle 8.1 bump, CI fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        java-version: ['11', '17', '19']
+        java-version: ['11', '17', '20']
 
     steps:
     - uses: actions/checkout@v3
@@ -76,15 +76,3 @@ jobs:
         fail_ci_if_error: false
         flags: java
         files: code-coverage/target/site/jacoco-aggregate-all/jacoco.xml,gradle-plugin/build/reports/jacoco/codeCoverageReport/codeCoverageReport.xml
-
-  finish:
-    # 'Ci Success' is the (only) required check for PRs, so we can change the jobs above without
-    # having to update the GH configuration every time.
-    name: CI Success
-    runs-on: ubuntu-22.04
-    needs:
-      - java
-    steps:
-      # Intentionally empty job (for all GH WF) events so that the "required checks" setting
-      # only needs to contain this job as the only required check for PRs.
-      - run: echo "Success"

--- a/gradle-plugin/gradle.properties
+++ b/gradle-plugin/gradle.properties
@@ -4,8 +4,8 @@ org.gradle.caching=true
 org.gradle.parallel=true
 # configure only necessary Gradle tasks
 org.gradle.configureondemand=true
-# also enable the configuration cache
-org.gradle.unsafe.configuration-cache=true
+# do not enable the configuration cache (spawning external processes :( )
+org.gradle.unsafe.configuration-cache=false
 # bump the Gradle daemon heap size (you can set bigger heap sizes as well)
 org.gradle.jvmargs=\
   -Xms2g -Xmx2g -XX:MaxMetaspaceSize=768m \

--- a/gradle-plugin/src/main/java/org/projectnessie/nessierunner/gradle/NessieRunnerTaskConfigurer.java
+++ b/gradle-plugin/src/main/java/org/projectnessie/nessierunner/gradle/NessieRunnerTaskConfigurer.java
@@ -26,7 +26,6 @@ import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.DependencySet;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFile;
-import org.gradle.api.plugins.ExtraPropertiesExtension;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskInputs;
@@ -91,10 +90,7 @@ public class NessieRunnerTaskConfigurer<T extends Task> implements Action<T> {
             ProcessState processState = new ProcessState();
             nessieRunnerServiceProvider.get().register(processState, t);
 
-            ExtraPropertiesExtension extra =
-                task.getExtensions().getByType(ExtraPropertiesExtension.class);
-
-            processState.quarkusStart(t, extension, extra, files, dependenciesString);
+            processState.quarkusStart(t, extension, files, dependenciesString);
 
             if (postStartAction != null) {
               postStartAction.execute((T) t);

--- a/gradle-plugin/src/main/java/org/projectnessie/nessierunner/gradle/ProcessState.java
+++ b/gradle-plugin/src/main/java/org/projectnessie/nessierunner/gradle/ProcessState.java
@@ -29,7 +29,6 @@ import org.gradle.api.GradleException;
 import org.gradle.api.Task;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFile;
-import org.gradle.api.plugins.ExtraPropertiesExtension;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.process.JavaForkOptions;
 import org.projectnessie.nessierunner.common.JavaVM;
@@ -50,7 +49,6 @@ public class ProcessState {
   void quarkusStart(
       Task task,
       NessieRunnerExtension extension,
-      ExtraPropertiesExtension extra,
       FileCollection appConfigFiles,
       String dependenciesString) {
 
@@ -162,10 +160,6 @@ public class ProcessState {
       throw new RuntimeException(e);
     }
     String listenPort = Integer.toString(URI.create(listenUrl).getPort());
-
-    // Add the Quarkus properties as "generic properties", so any task can use them.
-    extra.set(extension.getHttpListenUrlProperty().get(), listenUrl);
-    extra.set(extension.getHttpListenPortProperty().get(), listenPort);
 
     // Do not put the "dynamic" properties (quarkus.http.test-port) to the `Test` task's
     // system-properties, because those are subject to the test-task's inputs, which is used


### PR DESCRIPTION
* Remove ability to support "generic" tasks, which we never used.
* Fix CI workflow (remove `CI Success` job)

The Gradle version bump to 8.1 slipped through, causing that build issue w/ the configuration cache (new build-breaking probe related to the configuration cache checks in Gradle 8.1).