### PR TITLE
Fix issue preventing non-`JavaForkOptions` tasks to work

### DIFF
--- a/gradle-plugin/src/main/java/org/projectnessie/nessierunner/gradle/NessieRunnerTaskConfigurer.java
+++ b/gradle-plugin/src/main/java/org/projectnessie/nessierunner/gradle/NessieRunnerTaskConfigurer.java
@@ -81,8 +81,6 @@ public class NessieRunnerTaskConfigurer<T extends Task> implements Action<T> {
             ? appConfig.fileCollection(dependencies.toArray(new Dependency[0]))
             : null;
 
-    // Start the Nessie-Quarkus-App only when the Test task actually runs
-
     ExtraPropertiesExtension extra =
         task.getExtensions().findByType(ExtraPropertiesExtension.class);
     BiConsumer<String, String> urlAndPortConsumer =
@@ -97,6 +95,8 @@ public class NessieRunnerTaskConfigurer<T extends Task> implements Action<T> {
       task.notCompatibleWithConfigurationCache(
           "NessieRunner needs Gradle's extra-properties, which is incompatible with the configuration cache");
     }
+
+    // Start the Nessie-Quarkus-App only when the Test task actually runs
 
     task.usesService(nessieRunnerServiceProvider);
     task.doFirst(

--- a/gradle-plugin/src/main/java/org/projectnessie/nessierunner/gradle/ProcessState.java
+++ b/gradle-plugin/src/main/java/org/projectnessie/nessierunner/gradle/ProcessState.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
+import java.util.function.BiConsumer;
 import org.gradle.api.GradleException;
 import org.gradle.api.Task;
 import org.gradle.api.file.FileCollection;
@@ -50,7 +51,8 @@ public class ProcessState {
       Task task,
       NessieRunnerExtension extension,
       FileCollection appConfigFiles,
-      String dependenciesString) {
+      String dependenciesString,
+      BiConsumer<String, String> urlAndPortConsumer) {
 
     RegularFile configuredJar = extension.getExecutableJar().getOrNull();
 
@@ -160,6 +162,9 @@ public class ProcessState {
       throw new RuntimeException(e);
     }
     String listenPort = Integer.toString(URI.create(listenUrl).getPort());
+
+    // Add the Quarkus properties as "generic properties", so any task can use them.
+    urlAndPortConsumer.accept(listenUrl, listenPort);
 
     // Do not put the "dynamic" properties (quarkus.http.test-port) to the `Test` task's
     // system-properties, because those are subject to the test-task's inputs, which is used


### PR DESCRIPTION
The change from #183 introduced a bug that prevents the Gradle plugin being used for tasks that do not implement `JavaForkOptions`, for example `GatlingRunTask`.

This change brings back the removed setting of extra-properties.